### PR TITLE
fix error where model always thinking

### DIFF
--- a/internal/model_fetcher.go
+++ b/internal/model_fetcher.go
@@ -93,21 +93,21 @@ func initBuiltinMappings() {
 }
 func GetModelMapping(modelID string) (ModelMapping, bool) {
 	baseModel, enableThinking, enableSearch := ParseModelName(modelID)
+
 	mappingsLock.RLock()
 	defer mappingsLock.RUnlock()
+
 	if mapping, ok := modelMappings[baseModel]; ok {
-		if enableThinking {
-			mapping.EnableThinking = true
-		}
-		if enableSearch {
-			mapping.WebSearch = true
-			mapping.AutoWebSearch = true
-		}
+		mapping.EnableThinking = enableThinking
+		mapping.WebSearch = enableSearch
+		mapping.AutoWebSearch = enableSearch
 		return mapping, true
 	}
+
 	if mapping, ok := modelMappings[modelID]; ok {
 		return mapping, true
 	}
+
 	return ModelMapping{}, false
 }
 func GetUpstreamConfig(requestedModel string) *ModelMapping {


### PR DESCRIPTION
## Summary
- Fix model suffix handling so `-thinking` and `-search` explicitly control runtime features.
- Prevent base model defaults from forcing thinking/search mode on non-suffixed model names.

## Why
- Previously, if a base model mapping had `EnableThinking: true`, using a plain model name like `GLM-5.1` could still enable thinking mode unexpectedly.
- Users expect `GLM-5.1` to run without thinking, while `GLM-5.1-thinking` should explicitly enable thinking.

## Changes
- Updated `GetModelMapping` so parsed suffix flags override the base model mapping feature flags.
- `EnableThinking`, `WebSearch`, and `AutoWebSearch` are now derived from the requested model suffixes.
- This makes model behavior predictable:
  - `GLM-5.1` → thinking/search disabled
  - `GLM-5.1-thinking` → thinking enabled
  - `GLM-5.1-search` → search enabled
  - `GLM-5.1-thinking-search` → thinking and search enabled

## Test Plan
- [ ] 本地构建通过
- [ ] 关键功能已自测
- [ ] 如涉及接口变更，已验证兼容性
- [ ] 如涉及配置 / workflow 变更，已验证触发逻辑

## Checklist
- [ ] 已关联相关 Issue（如有）
- [ ] 已避免引入无关改动
- [ ] 已更新必要文档或说明（如适用）